### PR TITLE
replace pybind by torchbind

### DIFF
--- a/pytorch_binding/src/binding.cpp
+++ b/pytorch_binding/src/binding.cpp
@@ -9,14 +9,14 @@
     extern THCState* state;
 #endif
 
-int cpu_rnnt(torch::Tensor acts,
+int64_t cpu_rnnt(torch::Tensor acts,
             torch::Tensor labels,
             torch::Tensor input_lengths,
             torch::Tensor label_lengths,
             torch::Tensor costs,
             torch::Tensor grads,
-            int blank_label,
-            int num_threads) {
+            int64_t blank_label,
+            int64_t num_threads) {
 
     int maxT = acts.size(0);
     int maxU = acts.size(1);
@@ -81,14 +81,14 @@ int cpu_rnnt(torch::Tensor acts,
     return -1;
 }
 #ifdef WARPRNNT_ENABLE_GPU
-int gpu_rnnt(torch::Tensor acts,
+int64_t gpu_rnnt(torch::Tensor acts,
             torch::Tensor labels,
             torch::Tensor input_lengths,
             torch::Tensor label_lengths,
             torch::Tensor costs,
             torch::Tensor grads,
-            int blank_label,
-            int num_threads) {
+            int64_t blank_label,
+            int64_t num_threads) {
 
     int minibatch_size = acts.size(0);
     int maxT = acts.size(1);
@@ -154,9 +154,9 @@ int gpu_rnnt(torch::Tensor acts,
 }
 #endif
 
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("cpu_rnnt", &cpu_rnnt, "RNNT CPU version");
+TORCH_LIBRARY(warprnnt_pytorch_warp_rnnt, m) {
+    m.def("cpu_rnnt", &cpu_rnnt);
 #ifdef WARPRNNT_ENABLE_GPU
-    m.def("gpu_rnnt", &gpu_rnnt, "RNNT GPU version");
+    m.def("gpu_rnnt", &gpu_rnnt);
 #endif
 }

--- a/pytorch_binding/warprnnt_pytorch/__init__.py
+++ b/pytorch_binding/warprnnt_pytorch/__init__.py
@@ -1,9 +1,10 @@
+import importlib
 import torch
-import warprnnt_pytorch as warp_rnnt
 from torch.autograd import Function
 from torch.nn import Module
 
-from .warp_rnnt import *
+lib_path = importlib.util.find_spec("warprnnt_pytorch_warp_rnnt").origin
+torch.ops.load_library(lib_path)
 
 __all__ = ['rnnt_loss', 'RNNTLoss']
 
@@ -20,7 +21,7 @@ class _RNNT(Function):
 
         certify_inputs(acts, labels, act_lens, label_lens)
 
-        loss_func = warp_rnnt.gpu_rnnt if is_cuda else warp_rnnt.cpu_rnnt
+        loss_func = torch.ops.warprnnt_pytorch_warp_rnnt.gpu_rnnt if is_cuda else torch.ops.warprnnt_pytorch_warp_rnnt.cpu_rnnt
         grads = torch.zeros_like(acts) if acts.requires_grad else torch.zeros(0).to(acts)
         minibatch_size = acts.size(0)
         costs = torch.zeros(minibatch_size, dtype=acts.dtype)


### PR DESCRIPTION
Minimal changes to convert from pybind11 to torchbind.

Note: package name in [setup.py](https://github.com/vincentqb/warp-transducer/blob/master/pytorch_binding/setup.py#L50) not changed.